### PR TITLE
Feature/#33 backend implement seat bulk update service

### DIFF
--- a/Backend/SeatifyBackend/Api/Controllers/SeatsController.cs
+++ b/Backend/SeatifyBackend/Api/Controllers/SeatsController.cs
@@ -1,4 +1,4 @@
-﻿using Entities.Dtos.Seat;
+using Entities.Dtos.Seat;
 using Logic.Services;
 using Microsoft.AspNetCore.Mvc;
 
@@ -24,6 +24,22 @@ namespace Api.Controllers
             {
                 var created = await _seatService.CreateBatchAsync(dtos, ct);
                 return Ok(created);
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new { message = ex.Message });
+            }
+        }
+
+        [HttpPatch("seats/bulk")]
+        public async Task<ActionResult<BulkSeatUpdateResponseDto>> BulkUpdate(
+            [FromBody] BulkSeatUpdateDto dto,
+            CancellationToken ct)
+        {
+            try
+            {
+                var response = await _seatService.BulkUpdateAsync(dto, ct);
+                return Ok(response);
             }
             catch (ArgumentException ex)
             {

--- a/Backend/SeatifyBackend/Entities/Dtos/Seat/BulkSeatUpdateDto.cs
+++ b/Backend/SeatifyBackend/Entities/Dtos/Seat/BulkSeatUpdateDto.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace Entities.Dtos.Seat
+{
+    public class BulkSeatUpdateDto
+    {
+        [Required]
+        [MinLength(1, ErrorMessage = "At least one SeatId must be provided.")]
+        public List<string> SeatIds { get; set; } = new List<string>();
+
+        public string? SectorId { get; set; }
+
+        public string? SeatType { get; set; }
+
+        [Range(0, 999999)]
+        public decimal? PriceOverride { get; set; }
+
+        public bool ClearSector { get; set; }
+        public bool ClearPriceOverride { get; set; }
+    }
+}

--- a/Backend/SeatifyBackend/Entities/Dtos/Seat/BulkSeatUpdateResponseDto.cs
+++ b/Backend/SeatifyBackend/Entities/Dtos/Seat/BulkSeatUpdateResponseDto.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Entities.Dtos.Seat
+{
+    public class BulkSeatUpdateResponseDto
+    {
+        public int UpdatedCount { get; set; }
+        public List<string> UpdatedSeatIds { get; set; } = new List<string>();
+    }
+}

--- a/Backend/SeatifyBackend/Logic/Services/SeatService .cs
+++ b/Backend/SeatifyBackend/Logic/Services/SeatService .cs
@@ -1,4 +1,4 @@
-﻿using Data;
+using Data;
 using Entities.Dtos.Seat;
 using Entities.Models;
 using Microsoft.EntityFrameworkCore;
@@ -13,6 +13,7 @@ namespace Logic.Services
         Task<SeatViewDto?> GetByIdAsync(string seatId, CancellationToken ct);
         Task<SeatViewDto?> UpdateAsync(string seatId, SeatUpdateDto dto, CancellationToken ct);
         Task<bool> DeleteAsync(string seatId, CancellationToken ct);
+        Task<BulkSeatUpdateResponseDto> BulkUpdateAsync(BulkSeatUpdateDto dto, CancellationToken ct);
     }
 
     public class SeatService : ISeatService
@@ -238,6 +239,109 @@ namespace Logic.Services
                     UpdatedAtUtc = s.UpdatedAtUtc
                 })
                 .FirstOrDefaultAsync(ct);
+        }
+
+        public async Task<BulkSeatUpdateResponseDto> BulkUpdateAsync(BulkSeatUpdateDto dto, CancellationToken ct)
+        {
+            if (dto == null || dto.SeatIds == null || !dto.SeatIds.Any())
+            {
+                throw new ArgumentException("At least one SeatId must be provided.");
+            }
+
+            var uniqueSeatIds = dto.SeatIds.Select(sid => sid.Trim()).Distinct().ToList();
+
+            var seatsToUpdate = await _dbContext.Seats
+                .Where(s => uniqueSeatIds.Contains(s.Id))
+                .ToListAsync(ct);
+
+            if (seatsToUpdate.Count != uniqueSeatIds.Count)
+            {
+                var foundIds = seatsToUpdate.Select(s => s.Id).ToList();
+                var missingIds = uniqueSeatIds.Except(foundIds).ToList();
+                var missingIdsStr = string.Join(", ", missingIds);
+                throw new ArgumentException($"Some seats were not found: {missingIdsStr}");
+            }
+
+            var distinctMatrixIds = seatsToUpdate.Select(s => s.MatrixId).Distinct().ToList();
+            if (distinctMatrixIds.Count > 1)
+            {
+                throw new ArgumentException("All selected seats must belong to the same layout matrix.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(dto.SectorId))
+            {
+                var sectorId = dto.SectorId.Trim();
+                bool sectorExists = await _dbContext.Sectors.AnyAsync(s => s.Id == sectorId, ct);
+                if (!sectorExists)
+                {
+                    throw new ArgumentException($"Sector not found: {sectorId}");
+                }
+            }
+
+            SeatType? parsedSeatType = null;
+            if (!string.IsNullOrWhiteSpace(dto.SeatType))
+            {
+                parsedSeatType = ParseSeatType(dto.SeatType);
+            }
+
+            var updatedIds = new List<string>();
+
+            using var transaction = await _dbContext.Database.BeginTransactionAsync(ct);
+            try
+            {
+                foreach (var seat in seatsToUpdate)
+                {
+                    bool isModified = false;
+
+                    if (!string.IsNullOrWhiteSpace(dto.SectorId))
+                    {
+                        seat.SectorId = dto.SectorId.Trim();
+                        isModified = true;
+                    }
+                    else if (dto.ClearSector)
+                    {
+                        seat.SectorId = null;
+                        isModified = true;
+                    }
+
+                    if (parsedSeatType.HasValue)
+                    {
+                        seat.SeatType = parsedSeatType.Value;
+                        isModified = true;
+                    }
+
+                    if (dto.PriceOverride.HasValue)
+                    {
+                        seat.PriceOverride = dto.PriceOverride.Value;
+                        isModified = true;
+                    }
+                    else if (dto.ClearPriceOverride)
+                    {
+                        seat.PriceOverride = null;
+                        isModified = true;
+                    }
+
+                    if (isModified)
+                    {
+                        seat.UpdatedAtUtc = DateTime.UtcNow;
+                        updatedIds.Add(seat.Id);
+                    }
+                }
+
+                await _dbContext.SaveChangesAsync(ct);
+                await transaction.CommitAsync(ct);
+
+                return new BulkSeatUpdateResponseDto
+                {
+                    UpdatedCount = updatedIds.Count,
+                    UpdatedSeatIds = updatedIds
+                };
+            }
+            catch (Exception)
+            {
+                await transaction.RollbackAsync(ct);
+                throw;
+            }
         }
 
         public async Task<SeatViewDto?> UpdateAsync(string seatId, SeatUpdateDto dto, CancellationToken ct)


### PR DESCRIPTION
# Backend: Implement Seat Bulk Update Service

## Description
This PR introduces the backend service and API endpoint to support efficient mass editing of seats within a seating matrix. This ensures the frontend layout editor can update a group of selected seat IDs with the same modification in a single request instead of updating seats one by one.

This API is required by the frontend seat layout editor component:
**Related Frontend Issue:** [#37 [FRONTEND] Implement Seat Selection Tools](https://github.com/bprof-spec-codes/seatify/issues/37)

## Scope of Changes

- **DTOs Created:** Implemented `BulkSeatUpdateDto` (request payload) and `BulkSeatUpdateResponseDto` (response payload).
- **Service Logic (`SeatService`):** Added the `BulkUpdateAsync` method to handle logic for mass-editing seats.
- **Validations Implemented:** 
  - Verifies that at least one `SeatId` is provided.
  - Ensures all selected seats exist in the database.
  - Ensures all chosen seats belong strictly to the **same** layout matrix / auditorium.
  - Checks if the corresponding `SectorId` exists when assigned.
- **Transactional Consistency:** Integrated EF Core `BeginTransactionAsync` to ensure no partial modifications occur. Either all selected seats are successfully updated or the entire operation is rolled back.
- **Supported Modifications:**
  - Assign to `SectorId` or clear sector allocation entirely.
  - Alter the `SeatType` (e.g., Seat, Accessible, Aisle).
  - Define `PriceOverride` amounts or clear the seat-level overrides safely.
- **New API Endpoint:** Exposed `PATCH /api/seats/bulk` allowing the frontend layout matrix editor to consume this feature.

## Endpoint Details
**`PATCH /api/seats/bulk`**

**Request Payload Example:**
```json
{
  "seatIds": ["uuid-1", "uuid-2", "uuid-3"],
  "sectorId": "vip-sector-uuid",
  "seatType": "Seat",
  "priceOverride": 1500,
  "clearSector": false,
  "clearPriceOverride": false
}
