### PR TITLE
Add route guards for protected organizer pages

### DIFF
--- a/Frontend/SeatifyFrontend/src/app/app-routing.module.ts
+++ b/Frontend/SeatifyFrontend/src/app/app-routing.module.ts
@@ -18,16 +18,21 @@ import { PublicBookingLayoutComponent } from './pages/public-booking-layout/publ
 import { PublicBookingMapComponent } from './pages/public-booking-map/public-booking-map.component';
 import { PublicBookingCheckoutComponent } from './pages/public-booking-checkout/public-booking-checkout.component';
 import { PublicBookingSuccessComponent } from './pages/public-booking-success/public-booking-success.component';
+import { authGuard } from './guards/auth.guard';
+import { guestGuard } from './guards/guest.guard';
 
 export const routes: Routes = [
   { path: '', component: LandingPageComponent },
   { path: 'landingpage', component: LandingPageComponent },
-  { path: 'login', component: LoginPageComponent},
-  { path: 'register', component: RegisterPageComponent },
+
+  { path: 'login', component: LoginPageComponent, canActivate: [guestGuard] },
+  { path: 'register', component: RegisterPageComponent, canActivate: [guestGuard] },
 
   {
     path: 'dashboard',
     component: OrganizerLayoutComponent,
+    canActivate: [authGuard],
+    canActivateChild: [authGuard],
     children: [
       { path: '', component: OrganizerDashboardComponent },
       { path: 'venues', component: VenueDashboardComponent },
@@ -43,6 +48,7 @@ export const routes: Routes = [
   },
 
   { path: 'checkout', component: CheckoutComponent },
+
   {
     path: 'book/:slug/:occurrenceId',
     component: PublicBookingLayoutComponent,
@@ -52,7 +58,13 @@ export const routes: Routes = [
       { path: 'success', component: PublicBookingSuccessComponent }
     ]
   },
-  { path: 'layout-matrix/:auditoriumId/editor', component: LayoutMatrixEditorComponent },
+
+  {
+    path: 'layout-matrix/:auditoriumId/editor',
+    component: LayoutMatrixEditorComponent,
+    canActivate: [authGuard]
+  },
+
   { path: '**', redirectTo: '' },
 ];
 

--- a/Frontend/SeatifyFrontend/src/app/guards/auth.guard.spec.ts
+++ b/Frontend/SeatifyFrontend/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { authGuard } from './auth.guard';
+
+describe('authGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => authGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/Frontend/SeatifyFrontend/src/app/guards/auth.guard.ts
+++ b/Frontend/SeatifyFrontend/src/app/guards/auth.guard.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = (_route, state): boolean | UrlTree => {
+  const authService = inject(AuthService)
+  const router = inject(Router)
+
+  if (authService.isLoggedIn()) {
+    return true
+  }
+
+  return router.createUrlTree(['/login'], {
+    queryParams: {
+      returnUrl: state.url
+    }
+  })
+};

--- a/Frontend/SeatifyFrontend/src/app/guards/guest.guard.spec.ts
+++ b/Frontend/SeatifyFrontend/src/app/guards/guest.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { guestGuard } from './guest.guard';
+
+describe('guestGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => guestGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/Frontend/SeatifyFrontend/src/app/guards/guest.guard.ts
+++ b/Frontend/SeatifyFrontend/src/app/guards/guest.guard.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router, UrlTree } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const guestGuard: CanActivateFn = (): boolean | UrlTree => {
+  const authService = inject(AuthService)
+  const router = inject(Router)
+
+  if (!authService.isLoggedIn()) {
+    return true
+  }
+
+  return router.createUrlTree(['/dashboard'])
+};

--- a/Frontend/SeatifyFrontend/src/app/pages/login-page/login-page.component.ts
+++ b/Frontend/SeatifyFrontend/src/app/pages/login-page/login-page.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../../services/auth.service';
 
 @Component({
@@ -17,7 +17,8 @@ export class LoginPageComponent {
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) {
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
@@ -37,7 +38,7 @@ export class LoginPageComponent {
     this.authService.login(this.loginForm.getRawValue()).subscribe({
       next: () => {
         this.isSubmitting = false
-        this.router.navigate(['/dashboard'])
+        this.router.navigateByUrl(this.getReturnUrl())
       },
       error: (err: Error) => {
         this.isSubmitting = false
@@ -53,7 +54,7 @@ export class LoginPageComponent {
     this.authService.loginAsDev().subscribe({
       next: () => {
         this.isSubmitting = false
-        this.router.navigate(['/dashboard'])
+        this.router.navigateByUrl(this.getReturnUrl())
       },
       error: (err: Error) => {
         this.isSubmitting = false
@@ -64,5 +65,9 @@ export class LoginPageComponent {
 
   get f() {
     return this.loginForm.controls
+  }
+
+  private getReturnUrl(): string {
+    return this.route.snapshot.queryParamMap.get('returnUrl') || '/dashboard'
   }
 }

--- a/Frontend/SeatifyFrontend/src/app/services/auth.service.ts
+++ b/Frontend/SeatifyFrontend/src/app/services/auth.service.ts
@@ -10,7 +10,8 @@ import { AuthResponse, CurrentUser, LoginRequest, RegisterRequest } from '../mod
 export class AuthService {
   private readonly apiUrl = `${environment.baseApiUrl}/api/auth`;
   private readonly tokenKey = 'seatify_token';
-  private readonly currentUserKey = 'seatify_current_user';
+  private readonly currentUserKey = 'seatify_current_user'
+  private readonly expiresAtKey = 'seatify_expires_at'
 
   private currentUserSubject = new BehaviorSubject<CurrentUser | null>(this.getStoredUser());
   public currentUser$ = this.currentUserSubject.asObservable();
@@ -49,9 +50,10 @@ export class AuthService {
   }
 
   logout(): void {
-    localStorage.removeItem(this.tokenKey);
-    localStorage.removeItem(this.currentUserKey);
-    this.currentUserSubject.next(null);
+    localStorage.removeItem(this.tokenKey)
+    localStorage.removeItem(this.currentUserKey)
+    localStorage.removeItem(this.expiresAtKey)
+    this.currentUserSubject.next(null)
   }
 
   getToken(): string | null {
@@ -59,7 +61,18 @@ export class AuthService {
   }
 
   isLoggedIn(): boolean {
-    return !!this.getToken();
+    const token = this.getToken()
+
+    if (!token) {
+      return false
+    }
+
+    if (this.isTokenExpired()) {
+      this.logout()
+      return false
+    }
+
+    return true
   }
 
   getCurrentUserSnapshot(): CurrentUser | null {
@@ -67,16 +80,17 @@ export class AuthService {
   }
 
   private storeAuth(response: AuthResponse): void {
-    localStorage.setItem(this.tokenKey, response.token);
+    localStorage.setItem(this.tokenKey, response.token)
+    localStorage.setItem(this.expiresAtKey, response.expiresAtUtc)
 
     const user: CurrentUser = {
       organizerId: response.organizerId,
       email: response.email,
       name: response.name
-    };
+    }
 
-    localStorage.setItem(this.currentUserKey, JSON.stringify(user));
-    this.currentUserSubject.next(user);
+    localStorage.setItem(this.currentUserKey, JSON.stringify(user))
+    this.currentUserSubject.next(user)
   }
 
   private getStoredUser(): CurrentUser | null {
@@ -103,5 +117,21 @@ export class AuthService {
       'Unexpected error occurred.';
 
     return throwError(() => new Error(message));
+  }
+
+  private isTokenExpired(): boolean {
+    const rawExpiresAt = localStorage.getItem(this.expiresAtKey)
+
+    if (!rawExpiresAt) {
+      return false
+    }
+
+    const expiresAt = new Date(rawExpiresAt).getTime()
+
+    if (Number.isNaN(expiresAt)) {
+      return true
+    }
+
+    return expiresAt <= Date.now()
   }
 }


### PR DESCRIPTION
## Summary

This PR adds frontend route protection for organizer-only pages by introducing Angular route guards.

## Changes

- Added an `authGuard` to protect authenticated organizer routes.
- Protected the organizer dashboard and all child dashboard routes.
- Protected the layout matrix editor route.
- Added a `guestGuard` to prevent authenticated users from accessing the login and register pages.
- Updated login navigation to support redirecting users back to the originally requested protected page after successful login.
- Improved authentication state handling by checking stored token validity.

## Protected Routes

The following routes now require authentication:

- `/dashboard`
- `/dashboard/venues`
- `/dashboard/venues/form`
- `/dashboard/auditoriums/:venueId`
- `/dashboard/auditoriums/:venueId/form`
- `/dashboard/events`
- `/dashboard/events/new`
- `/dashboard/events/:eventId/edit`
- `/dashboard/events/:eventId/occurrences/new`
- `/dashboard/events/:eventId/occurrences/:id/edit`
- `/layout-matrix/:auditoriumId/editor`

## Public Routes

The customer-facing booking flow remains public:

- `/`
- `/checkout`
- `/landingpage`
- `/book/:slug/:occurrenceId`
- `/book/:slug/:occurrenceId/checkout`
- `/book/:slug/:occurrenceId/success`

## Notes

This change only protects frontend navigation. Backend endpoints still need proper authorization rules using `[Authorize]` to enforce real access control.