### PR TITLE
155 frontend booking session integration for checkout fix hardcoded data

### DIFF
--- a/Backend/SeatifyBackend/Entities/Dtos/Reservation/ReservationCreateDto.cs
+++ b/Backend/SeatifyBackend/Entities/Dtos/Reservation/ReservationCreateDto.cs
@@ -14,8 +14,6 @@ namespace Entities.Dtos.Reservation
         public string EventOccurrenceId { get; set; } = string.Empty;
 
         public List<ReservationSeatDto> Seats { get; set; } = new();
-
-        // TODO: later BookingSessionId
     }
     public class ReservationSeatDto
     {

--- a/Backend/SeatifyBackend/Entities/Models/EventOccurrence.cs
+++ b/Backend/SeatifyBackend/Entities/Models/EventOccurrence.cs
@@ -37,8 +37,5 @@ namespace Entities.Models
 
         public string? AppearanceId { get; set; }
         public virtual Appearance? Appearance { get; set; }
-
-        // TODO: BookingSession
-
     }
 }

--- a/Backend/SeatifyBackend/Logic/Services/ReservationService.cs
+++ b/Backend/SeatifyBackend/Logic/Services/ReservationService.cs
@@ -32,6 +32,12 @@ namespace Logic.Services
 
         public bool CreateReservation(string eventOccurrenceId, ReservationCreateDto dto)
         {
+            var eventOccurrence = _context.EventOccurrences.FirstOrDefault(eo => eo.Id == eventOccurrenceId);
+            if (eventOccurrence == null)
+            {
+                return false;
+            }
+
             var reservation = new Reservation
             {
                 EventOccurrenceId = eventOccurrenceId,
@@ -45,10 +51,11 @@ namespace Logic.Services
 
             foreach (var seat in dto.Seats)
             {
+                var finalPrice = calculateFinalSeatPrice(eventOccurrence.EventId, eventOccurrenceId, seat.SeatId);
                 reservation.ReservationSeats.Add(new ReservationSeat
                 {
                     SeatId = seat.SeatId,
-                    FinalPrice = 5000 // mock data for testing
+                    FinalPrice = finalPrice
                 });
             }
 


### PR DESCRIPTION
## PR: Booking Session Integration - Remove Hardcoded Data and Clean Up TODOs

### Overview
Fixes hardcoded pricing data and removes obsolete TODO comments related to BookingSession feature implementation.

### Changes

#### 1. Fix hardcoded FinalPrice in CreateReservation
- **File**: `Backend/SeatifyBackend/Logic/Services/ReservationService.cs`
- **Change**: Replace mock `FinalPrice = 5000` with proper `calculateFinalSeatPrice()` calculation
- **Impact**: Ensures pricing consistency across all reservation paths with proper override handling (Occurrence → Event → Seat → Sector)

#### 2. Remove obsolete TODO comments
- **Files**:
  - `Backend/SeatifyBackend/Entities/Models/EventOccurrence.cs`
  - `Backend/SeatifyBackend/Entities/Dtos/Reservation/ReservationCreateDto.cs`
- **Reason**: BookingSession feature is fully implemented in `CheckoutReservation` flow; navigation properties and TODO notes no longer needed